### PR TITLE
Upgrade for ASP.NET Core 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ notifications:
 env:
 - ASPNETCORE_ENVIRONMENT=Development
 mono: none
-dotnet: 1.0.1
+dotnet: 2.1.503
 script:
   - dotnet restore -v Minimal
-  - dotnet build src/SodaPop.ConfigExplorer.csproj -c Release 
+  - dotnet build src/SodaPop.ConfigExplorer.csproj -c Release
   - dotnet test tests/SodaPop.ConfigExplorer.Tests.csproj

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 os: Visual Studio 2017
-version: 1.0.{build}
+version: 2.0.{build}
 configuration: Release
 pull_requests:
   do_not_increment_build_number: true

--- a/samples/Program.cs
+++ b/samples/Program.cs
@@ -1,5 +1,7 @@
-﻿using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration.Json;
 
 namespace SodaPop.ConfigExplorer.Sample
 {
@@ -7,14 +9,20 @@ namespace SodaPop.ConfigExplorer.Sample
     {
         public static void Main(string[] args)
         {
-            var host = new WebHostBuilder()
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseStartup<Startup>()
-                .Build();
 
-            host.Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(c =>
+                {
+                    // Remove non-JSON configuration sources
+                    foreach (var source in c.Sources.Where(s => !(s is JsonConfigurationSource)).ToArray())
+                    {
+                        c.Sources.Remove(source);
+                    }
+                })
+                .UseStartup<Startup>();
     }
 }

--- a/samples/Properties/launchSettings.json
+++ b/samples/Properties/launchSettings.json
@@ -15,8 +15,13 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "AspNetConfigExplorer.Sample": {
-      "commandName": "Project"
+    "SodaPop.ConfigExplorer.Sample": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/samples/SodaPop.ConfigExplorer.Sample.csproj
+++ b/samples/SodaPop.ConfigExplorer.Sample.csproj
@@ -1,17 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Update="appsettings.json" CopyToPublishDirectory="Always">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Startup.cs
+++ b/samples/Startup.cs
@@ -1,43 +1,41 @@
-﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace SodaPop.ConfigExplorer.Sample
 {
     public class Startup
     {
-
         private const string DEFAULT_PATH = "/config";
 
-        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void ConfigureServices(IServiceCollection services)
+        { }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IConfiguration config)
         {
-            var config = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .Build();
-
-            loggerFactory.AddConsole();
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
 
-                app.UseConfigExplorer(config, new ConfigExplorerOptions //optional
+                app.UseConfigExplorer(config, new ConfigExplorerOptions // optional
                 {
-                    LocalHostOnly = true, //default
-                    PathMatch = DEFAULT_PATH, //default
-                    TryRedactConnectionStrings = true //default
+                    LocalHostOnly = true, // default
+                    PathMatch = DEFAULT_PATH, // default
+                    TryRedactConnectionStrings = true, // default
                 });
             }
 
-            app.Run((context) => context.Response.WriteAsync($"<!DOCTYPE html>" +
-                $"<html>" +
-                $"<body>" +
-                $"Browse to the demo here: <a href=\"{ DEFAULT_PATH }\">ASPNET Core Config Explorer</a>" +
-                $"</body>" +
-                $"</html>"));
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("<!DOCTYPE html><html>" +
+                    "<head><title>SodaPop.ConfigExplorer.Sample</title></head>" +
+                    "<body>" +
+                    $"<p>Browse to the demo here: <a href=\"{DEFAULT_PATH}\">Show configuration</a></p>" +
+                    "</body>" +
+                    "</html>");
+            });
         }
     }
 }

--- a/samples/appsettings.json
+++ b/samples/appsettings.json
@@ -1,9 +1,14 @@
-﻿{
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information"
+    }
+  },
   "Tier1": {
-    "SomeKey" :  "Some Value",
+    "SomeKey": "Some Value",
     "Tier2": {
       "ConnectionStrings": {
-        "Some secret Key" : "some secret value"
+        "Some secret Key": "some secret value"
       },
       "Tier3": {
         "Level3Option": "And it's value"

--- a/src/MiddlewareExtensions.cs
+++ b/src/MiddlewareExtensions.cs
@@ -8,13 +8,13 @@ namespace SodaPop.ConfigExplorer
     {
         public static IApplicationBuilder UseConfigExplorer(
             this IApplicationBuilder builder,
-            IConfigurationRoot configRoot,
+            IConfiguration config,
             ConfigExplorerOptions options = null)
         {
             options = options ?? new ConfigExplorerOptions();
 
             return builder.MapWhen(context => context.IsValid(options),
-                x => x.UseMiddleware<ConfigExplorerMiddleware>(configRoot, options));
+                x => x.UseMiddleware<ConfigExplorerMiddleware>(config, options));
         }
 
         //todo: make this less terribad

--- a/src/SodaPop.ConfigExplorer.csproj
+++ b/src/SodaPop.ConfigExplorer.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Chad Tolkien</Authors>
     <Company>Soda Digital</Company>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSufix></VersionSufix>
-    <Description>Middleware for ASPNET Core to diagnose what values are available from Configuration</Description>
+    <Description>Middleware for ASP.NET Core to diagnose what values are available from Configuration</Description>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/ctolkien/SodaPop.ConfigExplorer</RepositoryUrl>
     <PackageProjectUrl>https://github.com/ctolkien/SodaPop.ConfigExplorer</PackageProjectUrl>
@@ -18,9 +18,11 @@
     <EmbeddedResource CopyToOutputDirection="Always" Include="Layout.cshtml" />
     <EmbeddedResource CopyToOutputDirection="Always" Include="Configs.cshtml" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.0.5" />
-    <PackageReference Include="RazorLight" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.1" />
+    <PackageReference Include="RazorLight" Version="2.0.0-beta1" />
   </ItemGroup>
 
 </Project>

--- a/tests/IntegrationTests.cs
+++ b/tests/IntegrationTests.cs
@@ -8,12 +8,12 @@ using Xunit;
 
 namespace SodaPop.ConfigExplorer.Tests
 {
-    public class IntergrationTest
+    public class IntegrationTest
     {
         private readonly TestServer _server;
         private readonly HttpClient _client;
 
-        public IntergrationTest()
+        public IntegrationTest()
         {
             _server = new TestServer(new WebHostBuilder()
                 .UseStartup<Startup>());

--- a/tests/SodaPop.ConfigExplorer.Tests.csproj
+++ b/tests/SodaPop.ConfigExplorer.Tests.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="1.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Upgrade package to netstandard2.0.
- Update ASP.NET Core dependencies to 2.1.x.
- Update RazorLight dependency for Razor 2.x support.
- Change middleware to take an `IConfiguration` object instead of the
  configuration root to support passing child sections.
- Simplify loop over configuration.
- Migrate sample project to ASP.NET Core 2.1.

---

Remaining pain points:

- The dependency on RazorLight is really bad. Not only is this still a beta version right now, but also it is somewhat unnecessary considering that the package will be used inside of ASP.NET Core where Razor is already set up and available (especially so in the future when you can’t opt out of partial packages).

  Personally, I don’t like this rendering this with Razor at all, and I would rather want this to happen in direct code. Considering that Razor is really only being used for the layout here (since the `Configs.cshtml` view doesn’t really do anything), I think that we could simplify this and avoid Razor altogether.

- Despite Razor being used, there’s a lot of string concatenation going on for building the output. That should either move to Razor logic, or (if Razor is being removed here) move to maybe `IHtmlGenerator`.

- There are a lot of *“this is terrible”* TODOs that should actually be addressed at some point.

- The output is very verbose and does make it difficult to parse when there is a lot of configuration. This is especially true since the default web host builder comes with environment variables, so there are a lot of entries without a hierarchy. The output format should be changed in a way that allows to condense that.

  Ideally, the output would show the source and maybe allow filtering by configuration source but unfortunately the `IConfiguration` interface does not support that. So if we wanted to do that, we could only handle each provider separately and would have to depend on `IConfigurationRoot` at which point the displayed configuration could no longer be configured.

- Unit tests are non-existent. And unfortunately, the current architecture makes it difficult to test this. There should probably be some separation between a component that loads (and redacts) the configuration, a component that renders the output, and the middleware as an orchestrator in between.

- Code documentation is missing. The only documented method is… a private method. That should be improved once the API is stable.